### PR TITLE
bump converter tool to 5.1.15, adding support for .NET 6.0

### DIFF
--- a/FHIR-Converter/README.md
+++ b/FHIR-Converter/README.md
@@ -16,7 +16,7 @@ This extension provides an interactive editing and verification experience to cr
 
 ## Getting started
 
-Before using the extension, you need to confirm whether the [.Net Core 3.1](https://dotnet.microsoft.com/download/dotnet/3.1) is installed in your machine. If not, you should download it first.
+Before using the extension, you need to confirm whether the [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) is installed in your machine. If not, you should download it first.
 
 After you have installed the extension, follow these steps to edit the templates:
 1. Login to your ACR if needed.

--- a/FHIR-Converter/client/install-engine.sh
+++ b/FHIR-Converter/client/install-engine.sh
@@ -1,4 +1,4 @@
-version="5.1.0.7"
+version="5.1.15"
 
 if [ ! -d "engine-tmp" ]; then
     mkdir ./engine-tmp


### PR DESCRIPTION
This extension currently has a dependency on `Microsoft.Health.Fhir.Liquid.Converter.Tool` version 5.1.0.7. In turn, this depends on .NET Core 3.1. 

This pull request updates the `install-engine.sh` script, to bump the version from 5.1.0.7 to 5.1.15. The latter version, targets .NET 6.0.

> **Note:** I have not been able to test this end-to-end, as I was unable to get the extension to load locally in my dev environment. Any guidance here would be appreciated.